### PR TITLE
Ids 783 update ro crate ingestion script so it requires explicit paths

### DIFF
--- a/mytardis_rocrate_builder/rocrate_builder.py
+++ b/mytardis_rocrate_builder/rocrate_builder.py
@@ -476,9 +476,7 @@ class ROBuilder:
         else:
             dataset_obj = self.crate.add_dataset(
                 source=(
-                    self.crate.source / Path(directory)
-                    if self.crate.source
-                    else Path(directory)
+                    self.crate.source / Path(directory) if self.crate.source else None
                 ),
                 properties=properties,
                 dest_path=Path(directory),
@@ -519,7 +517,9 @@ class ROBuilder:
         if not dataset_obj:
             dataset_obj = self.crate.root_dataset
         properties["dataset"] = dataset_obj.id
-        destination_path = source
+        destination_path = Path(dataset_obj.id) / datafile.filepath.relative_to(
+            Path(dataset_obj.id)
+        )
         datafile_obj = self.crate.add_file(
             source=source,
             properties=properties,

--- a/mytardis_rocrate_builder/rocrate_builder.py
+++ b/mytardis_rocrate_builder/rocrate_builder.py
@@ -517,9 +517,9 @@ class ROBuilder:
         if not dataset_obj:
             dataset_obj = self.crate.root_dataset
         properties["dataset"] = dataset_obj.id
-        destination_path = Path(dataset_obj.id) / datafile.filepath.relative_to(
-            Path(dataset_obj.id)
-        )
+        destination_path = datafile.filepath
+        if relative_dest := datafile.filepath.relative_to(Path(dataset_obj.id)):
+            destination_path = Path(dataset_obj.id) / relative_dest
         datafile_obj = self.crate.add_file(
             source=source,
             properties=properties,

--- a/mytardis_rocrate_builder/rocrate_dataclasses/rocrate_dataclasses.py
+++ b/mytardis_rocrate_builder/rocrate_dataclasses/rocrate_dataclasses.py
@@ -259,6 +259,11 @@ class Dataset(MyTardisContextObject):
         ] + self.identifiers  # type: ignore
         self.schema_type = "Dataset"
 
+    @property
+    def id(self) -> str | int | float:
+        """Retrieve first ID to act as RO-Crate ID"""
+        return self.directory.as_posix()
+
     # mytardis_classification: str #NOT IN SCHEMA.ORG
     def update_path(self, new_path: Path) -> None:
         """Update the path of a dataset chanigng it's name and identifiers
@@ -267,7 +272,6 @@ class Dataset(MyTardisContextObject):
             new_path (Path): path to update the dataset to
         """
         self.directory = new_path
-        self.identifiers = [new_path.as_posix()]
 
 
 @dataclass
@@ -287,6 +291,11 @@ class Datafile(MyTardisContextObject):
         self.identifiers: list[str | int | float] = [  # type: ignore
             self.filepath.as_posix()
         ] + self.identifiers  # type: ignore
+
+    @property
+    def id(self) -> str | int | float:
+        """Retrieve first ID to act as RO-Crate ID"""
+        return self.filepath.as_posix()
 
     def update_to_root(self, dataset: Dataset) -> Path:
         """Update a datafile that is a child of a dataset so that dataset is now the root

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -372,30 +372,3 @@ def test_add_datafile(
         "metadata"
     ]
     assert added_datafile == test_rocrate_datafile
-
-
-# def test_add_project(
-#     builder: ROBuilder,
-#     test_rocrate_person: ROPerson,
-#     test_project: Project,
-# ) -> None:
-#     assert builder.add_project(test_project) == ContextEntity(
-#         builder.crate,
-#         "test-project",
-#         properties={
-#             "@type": "Project",
-#             "name": "Test Project",
-#             "description": "A sample project for test purposes",
-#             "principal_investigator": test_rocrate_person.id,
-#             "contributors": [test_rocrate_person.id, test_rocrate_person.id],
-#             "identifiers": ["test-raid", "another-id"],
-#         },
-#     )
-
-
-# def test_add_experiment(
-#     builder: ROBuilder,
-#     test_experiment: Experiment,
-#     test_rocrate_experiment: ContextEntity,
-# ) -> None:
-#     assert builder.add_experiment(test_experiment) == test_rocrate_experiment


### PR DESCRIPTION
- Identify datafiles and dataclasses with paths (as this is what RO-Crate uses)
- Modify destination paths and source so __copy_unlisted() is not called for datasets and datafiles will move if no dataset path or crate path is provided 