### PR TITLE
Add external manifests option for archives

### DIFF
--- a/mytardis_rocrate_builder/rocrate_writer.py
+++ b/mytardis_rocrate_builder/rocrate_writer.py
@@ -126,8 +126,7 @@ def get_manifests_in_crate(root_dir: Path) -> List[Path]:
     # avoid recursion as RO-Crates may contain a large volume of files
     result.extend(root_dir.glob("*manifest-*.txt"))
     if len(result) > 0:  # if there is a bagit manifest check data dir
-        ro_crates = (root_dir / "data").glob("*ro-crate-metadata.json")
-        result.extend([Path("data") / crate_path for crate_path in ro_crates])
+        result.extend((root_dir / "data").glob("*ro-crate-metadata.json"))
         return result
     # otherwise check for un-bagged RO-Crate
     result.extend(root_dir.glob("*ro-crate-metadata.json"))

--- a/mytardis_rocrate_builder/rocrate_writer.py
+++ b/mytardis_rocrate_builder/rocrate_writer.py
@@ -7,7 +7,7 @@ import shutil
 import tarfile
 import zipfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import bagit
 from gnupg import GPG, ImportResult
@@ -113,7 +113,7 @@ def bagit_crate(crate_path: Path, contact_name: str) -> None:
     )
 
 
-def get_manifests_in_crate(root_dir: Path) -> List[Path]:
+def get_manifests_in_crate(root_dir: Path) -> list[Path]:
     """Return a list of all manifest type files in the RO-Crate.
 
     Args:
@@ -122,7 +122,7 @@ def get_manifests_in_crate(root_dir: Path) -> List[Path]:
     Returns:
         List[Path]: a list of all bagit manifest or RO-crate metadata paths
     """
-    result: List[Path] = []
+    result: list[Path] = []
     # avoid recursion as RO-Crates may contain a large volume of files
     result.extend(root_dir.glob("*manifest-*.txt"))
     if len(result) > 0:  # if there is a bagit manifest check data dir
@@ -154,16 +154,15 @@ def create_manifests_directory(
     manifest_dir = output_location / (archive_name + "_manifests")
     manifest_dir.mkdir(parents=True)
     for manifest in manifests:
-        manifest_name = manifest.name
-        shutil.copy(str(manifest), str(manifest_dir / (manifest_name)))
+        shutil.copy(str(manifest), str(manifest_dir / manifest.name))
 
 
 def archive_crate(
     archive_type: str | None,
     output_location: Path,
     crate_location: Path,
-    validate: Optional[bool] = False,
-    external_manifests: Optional[bool] = False,
+    validate: bool = False,
+    external_manifests: bool = False,
 ) -> None:
     """Archive the RO-Crate as a TAR, GZIPPED TAR or ZIP archive
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import json
 import shutil
 from datetime import datetime
 from pathlib import Path
+from sys import platform
 from typing import Any, Dict, List
 
 from gnupg import GPG, GenKey
@@ -173,7 +174,19 @@ def test_passphrase():
 
 @fixture
 def test_gpg_binary_location() -> str:
-    return "/usr/bin/gpg"
+    if platform in ["linux", "linux2"]:
+        # linux
+        return "/usr/bin/gpg"
+    elif platform == "darwin":
+        # OS X
+        return "/opt/homebrew/bin/gpg"
+    elif platform == "win32":
+        # Windows
+        return "C:\\Program Files (x86)\\GnuPG\\bin\\gpg.exe"
+    raise NotImplementedError(
+        "Unknown OS, please define where the gpg executable binary can be located"
+    )
+    return ""
 
 
 @fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,6 +174,8 @@ def test_passphrase():
 
 @fixture
 def test_gpg_binary_location() -> str:
+    if gpg_which := shutil.which("gpg"):
+        return gpg_which
     if platform in ["linux", "linux2"]:
         # linux
         return "/usr/bin/gpg"

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -2,6 +2,7 @@
 # pylint: disable
 from datetime import datetime
 from pathlib import Path
+from sys import platform
 from typing import Any, Dict
 from unittest.mock import patch
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -2,7 +2,6 @@
 # pylint: disable
 from datetime import datetime
 from pathlib import Path
-from sys import platform
 from typing import Any, Dict
 from unittest.mock import patch
 

--- a/tests/test_rocrate_writer.py
+++ b/tests/test_rocrate_writer.py
@@ -301,7 +301,7 @@ def test_zip_crate(tmpdir, data_dir, builder, test_person_name, ro_crate_helpers
     # external_manifests is true so check external manifests have been created
     manifest_dir = tmpdir / "zipped_crate_manifests/"
     assert manifest_dir.is_dir()
-    assert Path(manifest_dir / "ro-crate-metadata.json").is_file()
+    assert (manifest_dir / "ro-crate-metadata.json").is_file()
 
 
 @mark.parametrize("tar_type,read_mode", [("tar.gz", "r:gz"), ("tar", "r")])


### PR DESCRIPTION
**Adds an option to create a copy of manifest files generated by RO-Crate and BagIT to an external directory when archiving crates**

The rationale for this is that when a crate is sent to tape storage as a .tar archive the entire .tar often ends up being retrieved to check a file manifest or metadata to confirm if the crate contains the desired data (as these are all packaged in the .tar).
With a copy of the manifests stored externally a small .txt or .json file is all that needs to be retrieved.

Also updated tests so that gpg binary dependent tests work on a wider range of platforms (without deferring this to ro-crate.py)
